### PR TITLE
Capture return value from transient operations

### DIFF
--- a/src/lookup/core.cljc
+++ b/src/lookup/core.cljc
@@ -144,16 +144,15 @@
 
 (defn ^:no-doc flatten-seqs* [xs coll]
   (reduce
-   (fn [_ x]
+   (fn [coll x]
      (if (seq? x)
        (flatten-seqs* x coll)
        (conj! coll x)))
-   nil xs))
+   coll xs))
 
 (defn ^:no-doc flatten-seqs [xs]
   (let [coll (transient [])]
-    (flatten-seqs* xs coll)
-    (persistent! coll)))
+    (persistent! (flatten-seqs* xs coll))))
 
 (defn ^:no-doc normalize-attrs [headers]
   (cond-> (dissoc headers :tag-name :children ::path)


### PR DESCRIPTION
As documented on https://clojure.org/reference/transients, "transients are not designed to be bashed in-place.".

In particular, whenever we `conj!` to a transient vector, we need to capture the new return value and treat it just as we would with regular immutable values.

An example showing how not doing so could lead to potential bugs:
```clj
(let [t (transient {})]
  (dotimes [i 100]
    (conj! t [i i]))
  (persistent! t))
;; => {0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7}
```

Due to how vectors are implemented, I couldn't exhibit the same bug with vectors, so I used a hash-map. But the principle still stands.